### PR TITLE
Limit which Mvc packages are pulled in

### DIFF
--- a/Hackney.Shared.Tenure/Hackney.Shared.Tenure.csproj
+++ b/Hackney.Shared.Tenure/Hackney.Shared.Tenure.csproj
@@ -13,11 +13,9 @@
  <ItemGroup>
    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.30.0" />
    <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
+   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
    <PackageReference Include="System.Text.Json" Version="5.0.2" />
  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-  </ItemGroup>
+	
 </Project>
 


### PR DESCRIPTION
Limit which Mvc packages are pulled in because including the entire Mvc 2.2 package will cause build conflicts when the package is used within a .net core 3.1 web api application.