### PR TITLE
Revise GitVersion config

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,21 +3,14 @@ mode: Mainline
 branches:
   master:
     regex: ^master$|^main$
-    tag: ''
     increment: Minor
-    prevent-increment-of-merged-branch-version: true
-    track-merge-target: false
-    tracks-release-branches: false
     is-source-branch-for: ['feature']
-    is-release-branch: false
+    is-mainline: true
   feature:
+    regex: feature[/-]
     tag: preview
-    increment: Inherit
+    increment: Minor
     source-branches: ['master', 'main']
-    prevent-increment-of-merged-branch-version: false
-    track-merge-target: false
-    tracks-release-branches: false
-    is-release-branch: false
 ignore:
   sha: []
 merge-message-formats: {}


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Fix an error where changes to the version number on the main branch were not reflected on feature branches.

### *What changes have we introduced*

Now versioning works as expected:
E.g. current version on main = `0.4.0`, feature branch package version = `0.5.0-preview0001`

You can see an example of this configuration working in the screenshot below:
![New GitVersion config](https://user-images.githubusercontent.com/41153116/135834945-04261768-3619-47a1-81bf-a604e0f9b329.png)