### PR TITLE
Added Equals and GetHashCode overrides to HouseholdMembers

### DIFF
--- a/Hackney.Shared.Tenure.Tests/Domain/HouseholdMembersTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Domain/HouseholdMembersTests.cs
@@ -1,0 +1,71 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Force.DeepCloner;
+using Hackney.Shared.Tenure.Domain;
+using System.Linq;
+using Xunit;
+
+namespace Hackney.Shared.Tenure.Tests.Domain
+{
+    public class HouseholdMembersTests
+    {
+        private readonly Fixture _fixture = new Fixture();
+        private HouseholdMembers _classUnderTest;
+
+        [Fact]
+        public void EqualsTestWrongTypeReturnsFalse()
+        {
+            _classUnderTest = _fixture.Create<HouseholdMembers>();
+            _classUnderTest.Equals("some string").Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsTestSameObjectReturnsTrue()
+        {
+            _classUnderTest = _fixture.Create<HouseholdMembers>();
+            _classUnderTest.Equals(_classUnderTest).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsTestEquivalentObjectReturnsTrue()
+        {
+            _classUnderTest = _fixture.Create<HouseholdMembers>();
+            var compare = _classUnderTest.DeepClone();
+            _classUnderTest.Equals(compare).Should().BeTrue();
+        }
+
+        [Fact]
+        public void EqualsTestDifferentObjectReturnsFalse()
+        {
+            _classUnderTest = _fixture.Create<HouseholdMembers>();
+            var compare = _fixture.Create<HouseholdMembers>();
+            _classUnderTest.Equals(compare).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsTestNullObjectReturnsFalse()
+        {
+            _classUnderTest = _fixture.Create<HouseholdMembers>();
+            _classUnderTest.Equals(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void EqualsTestWithNullsEquivalentObjectReturnsTrue()
+        {
+            _classUnderTest = new HouseholdMembers();
+            var compare = new HouseholdMembers();
+            _classUnderTest.Equals(compare).Should().BeTrue();
+        }
+
+        [Fact]
+        public void GetHashCodeTest()
+        {
+            _classUnderTest = _fixture.Create<HouseholdMembers>();
+            var propValues = _classUnderTest.GetType()
+                                .GetProperties()
+                                .Select(x => x.GetValue(_classUnderTest).ToString());
+            var expected = string.Join("", propValues).GetHashCode();
+            _classUnderTest.GetHashCode().Should().Be(expected);
+        }
+    }
+}

--- a/Hackney.Shared.Tenure.Tests/Hackney.Shared.Tenure.Tests.csproj
+++ b/Hackney.Shared.Tenure.Tests/Hackney.Shared.Tenure.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="DeepCloner" Version="0.10.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/Hackney.Shared.Tenure/Domain/HouseholdMembers.cs
+++ b/Hackney.Shared.Tenure/Domain/HouseholdMembers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 namespace Hackney.Shared.Tenure.Domain
 {
@@ -14,5 +15,31 @@ namespace Hackney.Shared.Tenure.Domain
 
         public DateTime DateOfBirth { get; set; }
         public PersonTenureType PersonTenureType { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (GetType() != obj?.GetType()) return false;
+            var otherObj = (HouseholdMembers)obj;
+            return otherObj != null
+                && Id.Equals(otherObj.Id)
+                && Type.Equals(otherObj.Type)
+                && (String.Compare(FullName, otherObj.FullName) == 0)
+                && IsResponsible.Equals(otherObj.IsResponsible)
+                && DateOfBirth.Equals(otherObj.DateOfBirth)
+                && PersonTenureType.Equals(otherObj.PersonTenureType);
+        }
+
+        public override int GetHashCode()
+        {
+            StringBuilder builder = new StringBuilder();
+            return builder.Append(Id.ToString())
+                          .Append(Type)
+                          .Append(FullName)
+                          .Append(IsResponsible)
+                          .Append(DateOfBirth)
+                          .Append(PersonTenureType)
+                          .ToString()
+                          .GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
Added Equals and GetHashCode overrides to HouseholdMembers.
This was previously implemented within the person listener and is used there to compare the household members collections within the event data for tenure events.