### PR TITLE
Add tenuredAsset to tenure shared

### DIFF
--- a/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
@@ -19,5 +19,6 @@ namespace Hackney.Shared.Tenure.Boundary.Requests
         public bool? HasOffsiteStorage { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
         public IEnumerable<LegacyReference> LegacyReferences { get; set; }
+        public TenuredAsset TenuredAsset { get; set; }
     }
 }


### PR DESCRIPTION
- Updating an Asset can take the form of editing an address
- The tenure-api maintains a small subset of tenure information which needs to be updated when there is a change to the asset address