### PR TITLE
Add temporary accommodation charges to the charges object

### DIFF
--- a/Hackney.Shared.Tenure/Domain/Charges.cs
+++ b/Hackney.Shared.Tenure/Domain/Charges.cs
@@ -21,5 +21,22 @@ namespace Hackney.Shared.Tenure.Domain
         public float OriginalRentCharge { get; set; }
 
         public float OriginalServiceCharge { get; set; }
+
+        /// <summary>
+        /// A separately-recorded storage charge
+        /// eg. for tenants using the council's storage facility.
+        /// </summary>
+        public float? StorageCharge { get; set; }
+
+        /// <summary>
+        /// An separately-recorded adjustment made to the standard rent,
+        /// usually a discount (eg. -20f).
+        /// </summary>
+        public float? RentAdjustment { get; set; }
+
+        /// <summary>
+        /// A reason given for the <see cref="RentAdjustment"/>
+        /// </summary>
+        public string RentAdjustmentReason { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[HT20-586: Move Storage to Booking page](https://hackney.atlassian.net/browse/HT20-586)
[HT20-694: Add rent adjustment editor to booking page](https://hackney.atlassian.net/browse/HT20-694)

## Describe this PR

### *What is the problem we're trying to solve*

The temporary accommodation application needs to record separate charges for storage and discounts in exceptional circumstances. These need to be independently managed by the finance team, and communicated as separate figures to the tenant.

### *What changes have we introduced*

Add separate fields to the charges object to store these new values.

### *Follow up actions after merging PR*

Once approved, we will need to amend the swagger documentation for the tenure API. We will also need to update all references to tenure shared in APIs and listeners.