### PR TITLE
Add potential end date to the edit tenure details request

### DIFF
--- a/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
@@ -14,6 +14,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests
         public TenureType TenureType { get; set; }
         public string TenureSource { get; set; }
         public Terminated Terminated { get; set; }
+        public DateTime? PotentialEndDate { get; set; }
         public string FundingSource { get; set; }
         public int NumberOfAdultsInProperty { get; set; }
         public int NumberOfChildrenInProperty { get; set; }


### PR DESCRIPTION
## Link to JIRA ticket

[HT20-732: Change tenure end date to save to potentialEndDate](https://hackney.atlassian.net/browse/HT20-732)

## Describe this PR

### *What is the problem we're trying to solve*

The Temporary Accommodation tool requires the potential end date to be added after tenure creation, as it is not always immediately known.

### *What changes have we introduced*

Add potential end date to the edit tenure details request object.

### *Follow up actions after merging PR*

Update the tenure API with the reference to the new package version.