### PR TITLE
HT20-661: Add IsTenureAccepted field to tenure

### DIFF
--- a/Hackney.Shared.Tenure/Domain/FurtherAccountInformation.cs
+++ b/Hackney.Shared.Tenure/Domain/FurtherAccountInformation.cs
@@ -8,5 +8,6 @@ namespace Hackney.Shared.Tenure.Domain
         public string NoRentAccountReason { get; set; }
         public DateTime? RentLetterSentDate { get; set; }
         public DateTime? RentCardGivenDate { get; set; }
+        public bool? IsTenureAccepted { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[Allow deferred rent account number creation for TA
](https://hackney.atlassian.net/browse/HT20-661)

## Describe this PR

### *What is the problem we're trying to solve*

This is to allow TA to defer the creation of rent account number.
The IsTenureAccepted field will allow the finance listener to create the number once appropriate (this part of work is currently in progress).

### *What changes have we introduced*

One new field within furtherAccountInformation 

### *Follow up actions after merging PR*

The tenure API, tenure listener and SwaggerHub will be updated to reflect this change.