### PR TITLE
HT20-661: Change format to date

### DIFF
--- a/Hackney.Shared.Tenure/Domain/FurtherAccountInformation.cs
+++ b/Hackney.Shared.Tenure/Domain/FurtherAccountInformation.cs
@@ -8,6 +8,6 @@ namespace Hackney.Shared.Tenure.Domain
         public string NoRentAccountReason { get; set; }
         public DateTime? RentLetterSentDate { get; set; }
         public DateTime? RentCardGivenDate { get; set; }
-        public bool? IsTenureAccepted { get; set; }
+        public DateTime? TenureAcceptedDate { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[Allow deferred rent account number creation for TA
](https://hackney.atlassian.net/browse/HT20-661)

## Describe this PR

### *What is the problem we're trying to solve*

This is to allow TA to defer the creation of rent account number.
After releasing [PR 23](https://github.com/LBHackney-IT/tenure-shared/pull/23), where this field was a bool, we agreed with the users that a date is actually how this info needs to be stored. So this PR is essentially changing the type to a date.

### *What changes have we introduced*

One changed field within furtherAccountInformation 

### *Follow up actions after merging PR*

The tenure API, tenure listener and SwaggerHub will be updated to reflect this change.