### PR TITLE
HT20-851: Add isSection208NoticeSent field

### DIFF
--- a/Hackney.Shared.Tenure/Domain/FurtherAccountInformation.cs
+++ b/Hackney.Shared.Tenure/Domain/FurtherAccountInformation.cs
@@ -9,5 +9,6 @@ namespace Hackney.Shared.Tenure.Domain
         public DateTime? RentLetterSentDate { get; set; }
         public DateTime? RentCardGivenDate { get; set; }
         public DateTime? TenureAcceptedDate { get; set; }
+        public bool? IsSection208NoticeSent { get; set; }
     }
 }


### PR DESCRIPTION
## Describe this PR
### *What is the problem we're trying to solve*

Users of the Book Temporary Accommodation tool need to know if a section 208 notice has been sent for accommodation placements outside of the borough.

### *What changes have we introduced*
One new field within the furtherAccountInformation sub-object

### *Follow up actions after merging PR*

The tenure API, tenure listener and SwaggerHub will be updated to reflect this change.