### PR TITLE
HT20-839: Add IsSuspended flag for TA

### DIFF
--- a/Hackney.Shared.Tenure/Domain/Charges.cs
+++ b/Hackney.Shared.Tenure/Domain/Charges.cs
@@ -38,5 +38,10 @@ namespace Hackney.Shared.Tenure.Domain
         /// A reason given for the <see cref="RentAdjustment"/>
         /// </summary>
         public string RentAdjustmentReason { get; set; }
+
+        /// <summary>
+        /// TA: this is to stop the tenant being charged
+        /// </summary>
+        public bool? IsSuspended { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[TA: Restore a historical booking
](https://hackney.atlassian.net/browse/HT20-839)
## Describe this PR

### *What is the problem we're trying to solve*

TA officers will need to be able to restore a historical booking so that when a resident’s circumstances change, they can remain in a TA property. To do so, there needs to be a field that stores the fact that payment has (or hasn't been) suspended for that booking)

### *What changes have we introduced*

Added an optional boolean flag in the charges entity.


### *Follow up actions after merging PR*

The tenure API, tenure listener and SwaggerHub will be updated to reflect this change.