### PR TITLE
Add TaOfficer and TaStatus

### DIFF
--- a/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
@@ -22,5 +22,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
         public IEnumerable<LegacyReference> LegacyReferences { get; set; }
         public TenuredAsset TenuredAsset { get; set; }
+        public string TaOfficer { get; set; }
+        public string TaStatus { get; set; }
     }
 }

--- a/Hackney.Shared.Tenure/Boundary/Response/TenureResponseObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Response/TenureResponseObject.cs
@@ -33,5 +33,7 @@ namespace Hackney.Shared.Tenure.Boundary.Response
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
+        public string TaOfficer { get; set; }
+        public string TaStatus { get; set; }
     }
 }

--- a/Hackney.Shared.Tenure/Domain/TenureInformation.cs
+++ b/Hackney.Shared.Tenure/Domain/TenureInformation.cs
@@ -36,6 +36,8 @@ namespace Hackney.Shared.Tenure.Domain
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
+        public string TaOfficer { get; set; }
+        public string TaStatus { get; set; }
 
     }
 }

--- a/Hackney.Shared.Tenure/Factories/EntityFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/EntityFactory.cs
@@ -35,7 +35,9 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = databaseEntity.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = databaseEntity.NumberOfChildrenInProperty,
                 HasOffsiteStorage = databaseEntity.HasOffsiteStorage,
-                FurtherAccountInformation = databaseEntity.FurtherAccountInformation
+                FurtherAccountInformation = databaseEntity.FurtherAccountInformation,
+                TaOfficer = databaseEntity.TaOfficer,
+                TaStatus = databaseEntity.TaStatus
             };
         }
 
@@ -69,7 +71,9 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = entity.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = entity.NumberOfChildrenInProperty,
                 HasOffsiteStorage = entity.HasOffsiteStorage,
-                FurtherAccountInformation = entity.FurtherAccountInformation
+                FurtherAccountInformation = entity.FurtherAccountInformation,
+                TaOfficer = entity.TaOfficer,
+                TaStatus = entity.TaStatus
             };
         }
     }

--- a/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
@@ -39,7 +39,9 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = domain.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = domain.NumberOfChildrenInProperty,
                 HasOffsiteStorage = domain.HasOffsiteStorage,
-                FurtherAccountInformation = domain.FurtherAccountInformation
+                FurtherAccountInformation = domain.FurtherAccountInformation,
+                TaOfficer = domain.TaOfficer,
+                TaStatus = domain.TaStatus
             };
         }
 

--- a/Hackney.Shared.Tenure/Infrastructure/TenureInformationDb.cs
+++ b/Hackney.Shared.Tenure/Infrastructure/TenureInformationDb.cs
@@ -91,5 +91,10 @@ namespace Hackney.Shared.Tenure.Infrastructure
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<FurtherAccountInformation>))]
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
 
+        [DynamoDBProperty]
+        public string TaOfficer { get; set; }
+
+        [DynamoDBProperty]
+        public string TaStatus { get; set; }
     }
 }


### PR DESCRIPTION
[TS-1315 View Bookings in Worktray](https://hackney.atlassian.net/browse/TS-1315)

# What

Add `TaOfficer` and `TaStatus` attributs to the `EditTenureDetailsRequestObject` and `TenureResponseObject` and all dependent classes.

# Why

This will allow clients (in this case the Temporary Accommodation frontend) to fetch and store these fields so that we can display and edit the workflow status of a temporary accommodation tenure, as well as the officer assigned to this.