### PR TITLE
Add "Booking Status" and "Assigned Officer" under a sub-model within Create, Update & Layer Tenure models.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# Token to access locked Hackney Shared Github packages
+LBHPACKAGESTOKEN=ghp_YourPATWithDownloadGithubPackagesPrivileges

--- a/Hackney.Shared.Tenure.Tests/Factories/CreateRequestFactoryTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/CreateRequestFactoryTests.cs
@@ -37,6 +37,8 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             databaseEntity.TenuredAsset.Should().BeEquivalentTo(request.TenuredAsset);
             databaseEntity.TenureType.Should().Be(request.TenureType);
             databaseEntity.Terminated.Should().Be(request.Terminated);
+            databaseEntity.TempAccInfo.Should().BeEquivalentTo(request.TempAccInfo);
+            databaseEntity.FurtherAccountInformation.Should().BeEquivalentTo(request.FurtherAccountInformation);
         }
 
         [Fact]

--- a/Hackney.Shared.Tenure.Tests/Factories/CreateRequestFactoryTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/CreateRequestFactoryTests.cs
@@ -37,7 +37,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             databaseEntity.TenuredAsset.Should().BeEquivalentTo(request.TenuredAsset);
             databaseEntity.TenureType.Should().Be(request.TenureType);
             databaseEntity.Terminated.Should().Be(request.Terminated);
-            databaseEntity.TempAccInfo.Should().BeEquivalentTo(request.TempAccInfo);
+            databaseEntity.TempAccommodationInfo.Should().BeEquivalentTo(request.TempAccommodationInfo);
             databaseEntity.FurtherAccountInformation.Should().BeEquivalentTo(request.FurtherAccountInformation);
         }
 

--- a/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
@@ -48,7 +48,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             var domainTenure = databaseEntity.ToDomain();
 
             // If it is null, cross-static-method calls are not properly covered.
-            domainTenure.TempAccInfo.Should().NotBeNull();
+            domainTenure.TempAccommodationInfo.Should().NotBeNull();
 
             databaseEntity.Should().BeEquivalentTo(domainTenure, config => config.Excluding(x => x.IsActive));
         }
@@ -62,7 +62,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             var databaseEntity = entity.ToDatabase();
 
             // If it is null, cross-static-method calls are not properly covered.
-            databaseEntity.TempAccInfo.Should().NotBeNull();
+            databaseEntity.TempAccommodationInfo.Should().NotBeNull();
 
             entity.Should().BeEquivalentTo(databaseEntity);
         }

--- a/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
@@ -48,8 +48,6 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             var domainTenure = databaseEntity.ToDomain();
 
             databaseEntity.Should().BeEquivalentTo(domainTenure, config => config.Excluding(x => x.IsActive));
-            // TODO: cover isActive????
-            // testing only the expired tenure???
 
             // If it is null, cross-static-method calls were not properly covered.
             domainTenure.TempAccInfo.Should().NotBeNull();

--- a/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
@@ -14,6 +14,32 @@ namespace Hackney.Shared.Tenure.Tests.Factories
 
         #region Tenure Information
         [Fact]
+        public void NullTenureDomainMapsToNullTenureDatabaseEntity()
+        {
+            // arrange
+            TenureInformation domainTenure = null;
+
+            // act
+            var entityTenure = domainTenure.ToDatabase();
+
+            // assert
+            entityTenure.Should().BeNull();
+        }
+
+        [Fact]
+        public void NullTenureDatabaseEntityMapsToNullTenureDomain()
+        {
+            // arrange
+            TenureInformationDb entityTenure = null;
+
+            // act
+            var domainTenure = entityTenure.ToDomain();
+
+            // assert
+            domainTenure.Should().BeNull();
+        }
+
+        [Fact]
         public void CanMapADatabaseEntityToADomainObject()
         {
             var databaseEntity = _fixture.Create<TenureInformationDb>();

--- a/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
@@ -47,10 +47,10 @@ namespace Hackney.Shared.Tenure.Tests.Factories
 
             var domainTenure = databaseEntity.ToDomain();
 
-            databaseEntity.Should().BeEquivalentTo(domainTenure, config => config.Excluding(x => x.IsActive));
-
-            // If it is null, cross-static-method calls were not properly covered.
+            // If it is null, cross-static-method calls are not properly covered.
             domainTenure.TempAccInfo.Should().NotBeNull();
+
+            databaseEntity.Should().BeEquivalentTo(domainTenure, config => config.Excluding(x => x.IsActive));
         }
 
         [Fact]
@@ -61,10 +61,10 @@ namespace Hackney.Shared.Tenure.Tests.Factories
 
             var databaseEntity = entity.ToDatabase();
 
-            entity.Should().BeEquivalentTo(databaseEntity);
-
-            // If it is null, cross-static-method calls were not properly covered.
+            // If it is null, cross-static-method calls are not properly covered.
             databaseEntity.TempAccInfo.Should().NotBeNull();
+
+            entity.Should().BeEquivalentTo(databaseEntity);
         }
         #endregion
         #region Temporary Accommodation Information
@@ -106,7 +106,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             taInfoEntity.BookingStatus.Should().Be(domainTAInfo.BookingStatus);
             // If it is null, cross-static-method calls were not properly covered.
             taInfoEntity.AssignedOfficer.Should().NotBeNull();
-            taInfoEntity.AssignedOfficer.Should().Be(domainTAInfo.AssignedOfficer);
+            taInfoEntity.AssignedOfficer.Should().BeEquivalentTo(domainTAInfo.AssignedOfficer);
         }
         [Fact]
         public void TAOfficerDomainMapsFieldsCorrectlyToTAOfficerDatabase()
@@ -161,7 +161,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             taInfoDomain.BookingStatus.Should().Be(entityTAInfo.BookingStatus);
             // If it is null, cross-static-method calls were not properly covered.
             taInfoDomain.AssignedOfficer.Should().NotBeNull();
-            taInfoDomain.AssignedOfficer.Should().Be(entityTAInfo.AssignedOfficer);
+            taInfoDomain.AssignedOfficer.Should().BeEquivalentTo(entityTAInfo.AssignedOfficer);
         }
         [Fact]
         public void TAOfficerEntityMapsFieldsCorrectlyToTAOfficerDomain()

--- a/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
@@ -12,17 +12,22 @@ namespace Hackney.Shared.Tenure.Tests.Factories
     {
         private readonly Fixture _fixture = new Fixture();
 
+        #region Tenure Information
         [Fact]
         public void CanMapADatabaseEntityToADomainObject()
         {
             var databaseEntity = _fixture.Create<TenureInformationDb>();
             databaseEntity.EndOfTenureDate = DateTime.UtcNow;
 
-            var entity = databaseEntity.ToDomain();
+            var domainTenure = databaseEntity.ToDomain();
 
-            databaseEntity.Should().BeEquivalentTo(entity, config => config.Excluding(x => x.IsActive));
+            databaseEntity.Should().BeEquivalentTo(domainTenure, config => config.Excluding(x => x.IsActive));
+            // TODO: cover isActive????
+            // testing only the expired tenure???
+
+            // If it is null, cross-static-method calls were not properly covered.
+            domainTenure.TempAccInfo.Should().NotBeNull();
         }
-
 
         [Fact]
         public void CanMapADomainEntityToADatabaseObject()
@@ -33,6 +38,122 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             var databaseEntity = entity.ToDatabase();
 
             entity.Should().BeEquivalentTo(databaseEntity);
+
+            // If it is null, cross-static-method calls were not properly covered.
+            databaseEntity.TempAccInfo.Should().NotBeNull();
         }
+        #endregion
+        #region Temporary Accommodation Information
+        #region Domain to Entity
+        [Fact]
+        public void NullTAOfficerDomainMapsToNullTAOfficerDatabase()
+        {
+            // arrange
+            TemporaryAccommodationOfficer domainTAOfficer = null;
+
+            // act
+            var taOfficerEntity = domainTAOfficer.ToDatabase();
+
+            // assert
+            taOfficerEntity.Should().BeNull();
+        }
+        [Fact]
+        public void NullTAInfoDomainMapsToNullTAInfoDatabase()
+        {
+            // arrange
+            TemporaryAccommodationInfo domainTAInfo = null;
+
+            // act
+            var taInfoEntity = domainTAInfo.ToDatabase();
+
+            // assert
+            taInfoEntity.Should().BeNull();
+        }
+        [Fact]
+        public void TAInfoDomainMapsFieldsCorrectlyToTAInfoDatabase()
+        {
+            // arrange
+            var domainTAInfo = _fixture.Create<TemporaryAccommodationInfo>();
+
+            // act
+            var taInfoEntity = domainTAInfo.ToDatabase();
+
+            // assert
+            taInfoEntity.BookingStatus.Should().Be(domainTAInfo.BookingStatus);
+            // If it is null, cross-static-method calls were not properly covered.
+            taInfoEntity.AssignedOfficer.Should().NotBeNull();
+            taInfoEntity.AssignedOfficer.Should().Be(domainTAInfo.AssignedOfficer);
+        }
+        [Fact]
+        public void TAOfficerDomainMapsFieldsCorrectlyToTAOfficerDatabase()
+        {
+            // arrange
+            var domainTAOfficer = _fixture.Create<TemporaryAccommodationOfficer>();
+
+            // act
+            var taOfficerEntity = domainTAOfficer.ToDatabase();
+
+            // assert
+            taOfficerEntity.FirstName.Should().Be(domainTAOfficer.FirstName);
+            taOfficerEntity.LastName.Should().Be(domainTAOfficer.LastName);
+            taOfficerEntity.Email.Should().Be(domainTAOfficer.Email);
+        }
+        #endregion
+        #region Entity to Domain
+        [Fact]
+        public void NullTAOfficerEntityMapsToNullTAOfficerDomain()
+        {
+            // arrange
+            TemporaryAccommodationOfficerDb entityTAOfficer = null;
+
+            // act
+            var taOfficerDomain = entityTAOfficer.ToDomain();
+
+            // assert
+            taOfficerDomain.Should().BeNull();
+        }
+        [Fact]
+        public void NullTAInfoEntityMapsToNullTAInfoDomain()
+        {
+            // arrange
+            TemporaryAccommodationInfoDb entityTAInfo = null;
+
+            // act
+            var taInfoDomain = entityTAInfo.ToDomain();
+
+            // assert
+            taInfoDomain.Should().BeNull();
+        }
+        [Fact]
+        public void TAInfoEntityMapsFieldsCorrectlyToTAInfoDomain()
+        {
+            // arrange
+            var entityTAInfo = _fixture.Create<TemporaryAccommodationInfoDb>();
+
+            // act
+            var taInfoDomain = entityTAInfo.ToDomain();
+
+            // assert
+            taInfoDomain.BookingStatus.Should().Be(entityTAInfo.BookingStatus);
+            // If it is null, cross-static-method calls were not properly covered.
+            taInfoDomain.AssignedOfficer.Should().NotBeNull();
+            taInfoDomain.AssignedOfficer.Should().Be(entityTAInfo.AssignedOfficer);
+        }
+        [Fact]
+        public void TAOfficerEntityMapsFieldsCorrectlyToTAOfficerDomain()
+        {
+            // arrange
+            var entityTAOfficer = _fixture.Create<TemporaryAccommodationOfficerDb>();
+
+            // act
+            var taOfficerDomain = entityTAOfficer.ToDomain();
+
+            // assert
+            taOfficerDomain.FirstName.Should().Be(entityTAOfficer.FirstName);
+            taOfficerDomain.LastName.Should().Be(entityTAOfficer.LastName);
+            taOfficerDomain.Email.Should().Be(entityTAOfficer.Email);
+        }
+        #endregion
+        #endregion
     }
 }

--- a/Hackney.Shared.Tenure.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/ResponseFactoryTest.cs
@@ -31,7 +31,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             domain.Should().BeEquivalentTo(response);
 
             // If it is null, cross-static-method calls were not properly covered.
-            response.TempAccInfo.Should().NotBeNull();
+            response.TempAccommodationInfo.Should().NotBeNull();
         }
 
         [Fact]

--- a/Hackney.Shared.Tenure.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/ResponseFactoryTest.cs
@@ -91,7 +91,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             taInfoPresentation.BookingStatus.Should().Be(domainTAInfo.BookingStatus);
             // If it is null, cross-static-method calls were not properly covered.
             taInfoPresentation.AssignedOfficer.Should().NotBeNull();
-            taInfoPresentation.AssignedOfficer.Should().Be(domainTAInfo.AssignedOfficer);
+            taInfoPresentation.AssignedOfficer.Should().BeEquivalentTo(domainTAInfo.AssignedOfficer);
         }
         [Fact]
         public void TAOfficerDomainMapsFieldsCorrectlyToTAOfficerResponse()

--- a/Hackney.Shared.Tenure.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/ResponseFactoryTest.cs
@@ -12,6 +12,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
     {
         private readonly Fixture _fixture = new Fixture();
 
+        #region Tenure Information
         [Fact]
         public void CanMapANullTenureInfoToAResponseObject()
         {
@@ -26,8 +27,11 @@ namespace Hackney.Shared.Tenure.Tests.Factories
         {
             var domain = _fixture.Create<TenureInformation>();
             var response = domain.ToResponse();
+
             domain.Should().BeEquivalentTo(response);
 
+            // If it is null, cross-static-method calls were not properly covered.
+            response.TempAccInfo.Should().NotBeNull();
         }
 
         [Fact]
@@ -48,5 +52,61 @@ namespace Hackney.Shared.Tenure.Tests.Factories
 
             responseNotes.Should().BeEmpty();
         }
+        #endregion
+        #region Temporary Accommodation details
+        [Fact]
+        public void NullTAOfficerDomainMapsToNullTAOfficerResponse()
+        {
+            // arrange
+            TemporaryAccommodationOfficer domainTAOfficer = null;
+
+            // act
+            var taOfficerPresentation = domainTAOfficer.ToResponse();
+
+            // assert
+            taOfficerPresentation.Should().BeNull();
+        }
+        [Fact]
+        public void NullTAInfoDomainMapsToNullTAInfoResponse()
+        {
+            // arrange
+            TemporaryAccommodationInfo domainTAInfo = null;
+
+            // act
+            var taInfoPresentation = domainTAInfo.ToResponse();
+
+            // assert
+            taInfoPresentation.Should().BeNull();
+        }
+        [Fact]
+        public void TAInfoDomainMapsFieldsCorrectlyToTAInfoResponse()
+        {
+            // arrange
+            var domainTAInfo = _fixture.Create<TemporaryAccommodationInfo>();
+
+            // act
+            var taInfoPresentation = domainTAInfo.ToResponse();
+
+            // assert
+            taInfoPresentation.BookingStatus.Should().Be(domainTAInfo.BookingStatus);
+            // If it is null, cross-static-method calls were not properly covered.
+            taInfoPresentation.AssignedOfficer.Should().NotBeNull();
+            taInfoPresentation.AssignedOfficer.Should().Be(domainTAInfo.AssignedOfficer);
+        }
+        [Fact]
+        public void TAOfficerDomainMapsFieldsCorrectlyToTAOfficerResponse()
+        {
+            // arrange
+            var domainTAOfficer = _fixture.Create<TemporaryAccommodationOfficer>();
+
+            // act
+            var taOfficerPresentation = domainTAOfficer.ToResponse();
+
+            // assert
+            taOfficerPresentation.FirstName.Should().Be(domainTAOfficer.FirstName);
+            taOfficerPresentation.LastName.Should().Be(domainTAOfficer.LastName);
+            taOfficerPresentation.Email.Should().Be(domainTAOfficer.Email);
+        }
+        #endregion
     }
 }

--- a/Hackney.Shared.Tenure/Boundary/Requests/CreateTenureRequestObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/CreateTenureRequestObject.cs
@@ -31,7 +31,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests
         public int NumberOfAdultsInProperty { get; set; }
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
-        public TemporaryAccommodationInfo TempAccInfo { get; set; }
+        public TemporaryAccommodationInfo TempAccommodationInfo { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
     }
 }

--- a/Hackney.Shared.Tenure/Boundary/Requests/CreateTenureRequestObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/CreateTenureRequestObject.cs
@@ -31,6 +31,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests
         public int NumberOfAdultsInProperty { get; set; }
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
+        public TemporaryAccommodationInfo TempAccInfo { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
     }
 }

--- a/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
@@ -20,7 +20,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
         // Using a Domain (instead of Request) model because of limitations & risks imposed by the over-engineered entity updater solution
-        public TemporaryAccommodationInfo TempAccInfo { get; set; }
+        public TemporaryAccommodationInfo TempAccommodationInfo { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
         public IEnumerable<LegacyReference> LegacyReferences { get; set; }
         public TenuredAsset TenuredAsset { get; set; }

--- a/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/EditTenureDetailsRequestObject.cs
@@ -19,6 +19,8 @@ namespace Hackney.Shared.Tenure.Boundary.Requests
         public int NumberOfAdultsInProperty { get; set; }
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
+        // Using a Domain (instead of Request) model because of limitations & risks imposed by the over-engineered entity updater solution
+        public TemporaryAccommodationInfo TempAccInfo { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
         public IEnumerable<LegacyReference> LegacyReferences { get; set; }
         public TenuredAsset TenuredAsset { get; set; }

--- a/Hackney.Shared.Tenure/Boundary/Response/TemporaryAccommodationInfoResponse.cs
+++ b/Hackney.Shared.Tenure/Boundary/Response/TemporaryAccommodationInfoResponse.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Hackney.Shared.Tenure.Boundary.Response
+{
+    public class TemporaryAccommodationInfoResponse
+    {
+        public string BookingStatus { get; set; }
+        public TemporaryAccommodationOfficerResponse AssignedOfficer { get; set; }
+    }
+}

--- a/Hackney.Shared.Tenure/Boundary/Response/TemporaryAccommodationOfficerResponse.cs
+++ b/Hackney.Shared.Tenure/Boundary/Response/TemporaryAccommodationOfficerResponse.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Hackney.Shared.Tenure.Boundary.Response
+{
+    public class TemporaryAccommodationOfficerResponse
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Hackney.Shared.Tenure/Boundary/Response/TenureResponseObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Response/TenureResponseObject.cs
@@ -32,6 +32,7 @@ namespace Hackney.Shared.Tenure.Boundary.Response
         public int NumberOfAdultsInProperty { get; set; }
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
+        public TemporaryAccommodationInfoResponse TempAccInfo { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
     }
 }

--- a/Hackney.Shared.Tenure/Boundary/Response/TenureResponseObject.cs
+++ b/Hackney.Shared.Tenure/Boundary/Response/TenureResponseObject.cs
@@ -32,7 +32,7 @@ namespace Hackney.Shared.Tenure.Boundary.Response
         public int NumberOfAdultsInProperty { get; set; }
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
-        public TemporaryAccommodationInfoResponse TempAccInfo { get; set; }
+        public TemporaryAccommodationInfoResponse TempAccommodationInfo { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
     }
 }

--- a/Hackney.Shared.Tenure/Domain/TemporaryAccommodationInfo.cs
+++ b/Hackney.Shared.Tenure/Domain/TemporaryAccommodationInfo.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Hackney.Shared.Tenure.Domain
+{
+    public class TemporaryAccommodationInfo
+    {
+        public string BookingStatus { get; set; }
+        public TemporaryAccommodationOfficer AssignedOfficer { get; set; }
+    }
+}

--- a/Hackney.Shared.Tenure/Domain/TemporaryAccommodationOfficer.cs
+++ b/Hackney.Shared.Tenure/Domain/TemporaryAccommodationOfficer.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Hackney.Shared.Tenure.Domain
+{
+    public class TemporaryAccommodationOfficer
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Hackney.Shared.Tenure/Domain/TenureInformation.cs
+++ b/Hackney.Shared.Tenure/Domain/TenureInformation.cs
@@ -35,6 +35,7 @@ namespace Hackney.Shared.Tenure.Domain
         public int NumberOfAdultsInProperty { get; set; }
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
+        public TemporaryAccommodationInfo TempAccInfo { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
 
     }

--- a/Hackney.Shared.Tenure/Domain/TenureInformation.cs
+++ b/Hackney.Shared.Tenure/Domain/TenureInformation.cs
@@ -35,7 +35,7 @@ namespace Hackney.Shared.Tenure.Domain
         public int NumberOfAdultsInProperty { get; set; }
         public int NumberOfChildrenInProperty { get; set; }
         public bool? HasOffsiteStorage { get; set; }
-        public TemporaryAccommodationInfo TempAccInfo { get; set; }
+        public TemporaryAccommodationInfo TempAccommodationInfo { get; set; }
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
 
     }

--- a/Hackney.Shared.Tenure/Factories/CreateRequestFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/CreateRequestFactory.cs
@@ -35,7 +35,7 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = createTenureRequestObject.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = createTenureRequestObject.NumberOfChildrenInProperty,
                 HasOffsiteStorage = createTenureRequestObject.HasOffsiteStorage,
-                TempAccInfo = createTenureRequestObject.TempAccInfo.ToDatabase(),
+                TempAccommodationInfo = createTenureRequestObject.TempAccommodationInfo.ToDatabase(),
                 FurtherAccountInformation = createTenureRequestObject.FurtherAccountInformation
             };
         }

--- a/Hackney.Shared.Tenure/Factories/CreateRequestFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/CreateRequestFactory.cs
@@ -35,6 +35,7 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = createTenureRequestObject.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = createTenureRequestObject.NumberOfChildrenInProperty,
                 HasOffsiteStorage = createTenureRequestObject.HasOffsiteStorage,
+                TempAccInfo = createTenureRequestObject.TempAccInfo.ToDatabase(),
                 FurtherAccountInformation = createTenureRequestObject.FurtherAccountInformation
             };
         }

--- a/Hackney.Shared.Tenure/Factories/EntityFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/EntityFactory.cs
@@ -40,6 +40,7 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = databaseEntity.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = databaseEntity.NumberOfChildrenInProperty,
                 HasOffsiteStorage = databaseEntity.HasOffsiteStorage,
+                TempAccInfo = databaseEntity.TempAccInfo.ToDomain(),
                 FurtherAccountInformation = databaseEntity.FurtherAccountInformation
             };
         }

--- a/Hackney.Shared.Tenure/Factories/EntityFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/EntityFactory.cs
@@ -1,3 +1,4 @@
+using Hackney.Shared.Tenure.Boundary.Response;
 using Hackney.Shared.Tenure.Domain;
 using Hackney.Shared.Tenure.Infrastructure;
 
@@ -5,6 +6,8 @@ namespace Hackney.Shared.Tenure.Factories
 {
     public static class EntityFactory
     {
+        #region Tenure Information
+        // Entity to Domain
         public static TenureInformation ToDomain(this TenureInformationDb databaseEntity)
         {
             return new TenureInformation
@@ -39,38 +42,90 @@ namespace Hackney.Shared.Tenure.Factories
             };
         }
 
-        public static TenureInformationDb ToDatabase(this TenureInformation entity)
+        // Domain to Entity
+        public static TenureInformationDb ToDatabase(this TenureInformation domain)
         {
             return new TenureInformationDb
             {
-                Id = entity.Id,
-                Terminated = entity.Terminated,
-                TenureType = entity.TenureType,
-                TenureSource = entity.TenureSource,
-                TenuredAsset = entity.TenuredAsset,
-                SuccessionDate = entity.SuccessionDate,
-                AgreementType = entity.AgreementType,
-                Charges = entity.Charges,
-                EndOfTenureDate = entity.EndOfTenureDate,
-                EvictionDate = entity.EvictionDate,
-                HouseholdMembers = entity.HouseholdMembers.ToListOrEmpty(),
-                InformHousingBenefitsForChanges = entity.InformHousingBenefitsForChanges,
-                IsMutualExchange = entity.IsMutualExchange,
-                IsSublet = entity.IsSublet,
-                IsTenanted = entity.IsTenanted,
-                LegacyReferences = entity.LegacyReferences.ToListOrEmpty(),
-                Notices = entity.Notices.ToListOrEmpty(),
-                PaymentReference = entity.PaymentReference,
-                PotentialEndDate = entity.PotentialEndDate,
-                StartOfTenureDate = entity.StartOfTenureDate,
-                SubletEndDate = entity.SubletEndDate,
-                VersionNumber = entity.VersionNumber,
-                FundingSource = entity.FundingSource,
-                NumberOfAdultsInProperty = entity.NumberOfAdultsInProperty,
-                NumberOfChildrenInProperty = entity.NumberOfChildrenInProperty,
-                HasOffsiteStorage = entity.HasOffsiteStorage,
-                FurtherAccountInformation = entity.FurtherAccountInformation
+                Id = domain.Id,
+                Terminated = domain.Terminated,
+                TenureType = domain.TenureType,
+                TenureSource = domain.TenureSource,
+                TenuredAsset = domain.TenuredAsset,
+                SuccessionDate = domain.SuccessionDate,
+                AgreementType = domain.AgreementType,
+                Charges = domain.Charges,
+                EndOfTenureDate = domain.EndOfTenureDate,
+                EvictionDate = domain.EvictionDate,
+                HouseholdMembers = domain.HouseholdMembers.ToListOrEmpty(),
+                InformHousingBenefitsForChanges = domain.InformHousingBenefitsForChanges,
+                IsMutualExchange = domain.IsMutualExchange,
+                IsSublet = domain.IsSublet,
+                IsTenanted = domain.IsTenanted,
+                LegacyReferences = domain.LegacyReferences.ToListOrEmpty(),
+                Notices = domain.Notices.ToListOrEmpty(),
+                PaymentReference = domain.PaymentReference,
+                PotentialEndDate = domain.PotentialEndDate,
+                StartOfTenureDate = domain.StartOfTenureDate,
+                SubletEndDate = domain.SubletEndDate,
+                VersionNumber = domain.VersionNumber,
+                FundingSource = domain.FundingSource,
+                NumberOfAdultsInProperty = domain.NumberOfAdultsInProperty,
+                NumberOfChildrenInProperty = domain.NumberOfChildrenInProperty,
+                HasOffsiteStorage = domain.HasOffsiteStorage,
+                TempAccInfo = domain.TempAccInfo.ToDatabase(),
+                FurtherAccountInformation = domain.FurtherAccountInformation
             };
         }
+        #endregion
+        #region Temporary Accommodation Information
+        // Entity to Domain
+        public static TemporaryAccommodationOfficer ToDomain(this TemporaryAccommodationOfficerDb taOfficerEntity)
+        {
+            if (taOfficerEntity == null) return null;
+
+            return new TemporaryAccommodationOfficer
+            {
+                FirstName = taOfficerEntity.FirstName,
+                LastName = taOfficerEntity.LastName,
+                Email = taOfficerEntity.Email
+            };
+        }
+        // Entity to Domain
+        public static TemporaryAccommodationInfo ToDomain(this TemporaryAccommodationInfoDb taInfoEntity)
+        {
+            if (taInfoEntity == null) return null;
+
+            return new TemporaryAccommodationInfo
+            {
+                BookingStatus = taInfoEntity.BookingStatus,
+                AssignedOfficer = taInfoEntity.AssignedOfficer.ToDomain()
+            };
+        }
+
+        // Entity to Domain
+        public static TemporaryAccommodationOfficerDb ToDatabase(this TemporaryAccommodationOfficer taOfficerDomain)
+        {
+            if (taOfficerDomain == null) return null;
+
+            return new TemporaryAccommodationOfficerDb
+            {
+                FirstName = taOfficerDomain.FirstName,
+                LastName = taOfficerDomain.LastName,
+                Email = taOfficerDomain.Email
+            };
+        }
+        // Entity to Domain
+        public static TemporaryAccommodationInfoDb ToDatabase(this TemporaryAccommodationInfo taInfoDomain)
+        {
+            if (taInfoDomain == null) return null;
+
+            return new TemporaryAccommodationInfoDb
+            {
+                BookingStatus = taInfoDomain.BookingStatus,
+                AssignedOfficer = taInfoDomain.AssignedOfficer.ToDatabase()
+            };
+        }
+        #endregion
     }
 }

--- a/Hackney.Shared.Tenure/Factories/EntityFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/EntityFactory.cs
@@ -40,7 +40,7 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = databaseEntity.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = databaseEntity.NumberOfChildrenInProperty,
                 HasOffsiteStorage = databaseEntity.HasOffsiteStorage,
-                TempAccInfo = databaseEntity.TempAccInfo.ToDomain(),
+                TempAccommodationInfo = databaseEntity.TempAccommodationInfo.ToDomain(),
                 FurtherAccountInformation = databaseEntity.FurtherAccountInformation
             };
         }
@@ -78,7 +78,7 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = domain.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = domain.NumberOfChildrenInProperty,
                 HasOffsiteStorage = domain.HasOffsiteStorage,
-                TempAccInfo = domain.TempAccInfo.ToDatabase(),
+                TempAccommodationInfo = domain.TempAccommodationInfo.ToDatabase(),
                 FurtherAccountInformation = domain.FurtherAccountInformation
             };
         }

--- a/Hackney.Shared.Tenure/Factories/EntityFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/EntityFactory.cs
@@ -10,6 +10,8 @@ namespace Hackney.Shared.Tenure.Factories
         // Entity to Domain
         public static TenureInformation ToDomain(this TenureInformationDb databaseEntity)
         {
+            if (databaseEntity == null) return null;
+
             return new TenureInformation
             {
                 Id = databaseEntity.Id,
@@ -45,6 +47,8 @@ namespace Hackney.Shared.Tenure.Factories
         // Domain to Entity
         public static TenureInformationDb ToDatabase(this TenureInformation domain)
         {
+            if (domain == null) return null;
+
             return new TenureInformationDb
             {
                 Id = domain.Id,

--- a/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
@@ -8,6 +8,7 @@ namespace Hackney.Shared.Tenure.Factories
 {
     public static class ResponseFactory
     {
+        #region Tenure Information
         public static TenureResponseObject ToResponse(this TenureInformation domain)
         {
             if (domain == null) return null;
@@ -39,6 +40,7 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = domain.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = domain.NumberOfChildrenInProperty,
                 HasOffsiteStorage = domain.HasOffsiteStorage,
+                TempAccInfo = domain.TempAccInfo.ToResponse(),
                 FurtherAccountInformation = domain.FurtherAccountInformation
             };
         }
@@ -48,7 +50,26 @@ namespace Hackney.Shared.Tenure.Factories
             if (null == domainList) return new List<TenureResponseObject>();
             return domainList.Select(domain => ToResponse(domain)).ToList();
         }
+        #endregion
+        #region Temporary Accommodation Information
+        public static TemporaryAccommodationOfficerResponse ToResponse(this TemporaryAccommodationOfficer taOfficerDomain)
+        {
+            return new TemporaryAccommodationOfficerResponse
+            {
+                FirstName = taOfficerDomain.FirstName,
+                LastName = taOfficerDomain.LastName,
+                Email = taOfficerDomain.Email
+            };
+        }
 
-
+        public static TemporaryAccommodationInfoResponse ToResponse(this TemporaryAccommodationInfo taInfoDomain)
+        {
+            return new TemporaryAccommodationInfoResponse
+            {
+                BookingStatus = taInfoDomain.BookingStatus,
+                AssignedOfficer = taInfoDomain.AssignedOfficer.ToResponse()
+            };
+        }
+        #endregion
     }
 }

--- a/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
@@ -54,6 +54,8 @@ namespace Hackney.Shared.Tenure.Factories
         #region Temporary Accommodation Information
         public static TemporaryAccommodationOfficerResponse ToResponse(this TemporaryAccommodationOfficer taOfficerDomain)
         {
+            if (taOfficerDomain == null) return null;
+
             return new TemporaryAccommodationOfficerResponse
             {
                 FirstName = taOfficerDomain.FirstName,
@@ -64,6 +66,8 @@ namespace Hackney.Shared.Tenure.Factories
 
         public static TemporaryAccommodationInfoResponse ToResponse(this TemporaryAccommodationInfo taInfoDomain)
         {
+            if (taInfoDomain == null) return null;
+
             return new TemporaryAccommodationInfoResponse
             {
                 BookingStatus = taInfoDomain.BookingStatus,

--- a/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
@@ -40,7 +40,7 @@ namespace Hackney.Shared.Tenure.Factories
                 NumberOfAdultsInProperty = domain.NumberOfAdultsInProperty,
                 NumberOfChildrenInProperty = domain.NumberOfChildrenInProperty,
                 HasOffsiteStorage = domain.HasOffsiteStorage,
-                TempAccInfo = domain.TempAccInfo.ToResponse(),
+                TempAccommodationInfo = domain.TempAccommodationInfo.ToResponse(),
                 FurtherAccountInformation = domain.FurtherAccountInformation
             };
         }

--- a/Hackney.Shared.Tenure/Infrastructure/TemporaryAccommodationInfoDb.cs
+++ b/Hackney.Shared.Tenure/Infrastructure/TemporaryAccommodationInfoDb.cs
@@ -6,7 +6,11 @@ namespace Hackney.Shared.Tenure.Infrastructure
     {
         /// <summary>
         /// Represents the stage the Temporary Accomodation tenure is in.
-        /// Possible values: Matched | Under Offer | Accepted | Processing | Awaiting Approval | Completed
+        /// Some possible values for convenient developer reference:
+        /// Matched | Under Offer | Accepted | Processing | Awaiting Approval | Completed
+        /// 
+        /// This list is not guaranteed to stay up to date.
+        /// If that is a concern, please reference the Reference Data Google Sheet instead.
         /// </summary>
         public string BookingStatus { get; set; }
         public TemporaryAccommodationOfficerDb AssignedOfficer { get; set; }

--- a/Hackney.Shared.Tenure/Infrastructure/TemporaryAccommodationInfoDb.cs
+++ b/Hackney.Shared.Tenure/Infrastructure/TemporaryAccommodationInfoDb.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Hackney.Shared.Tenure.Infrastructure
+{
+    public class TemporaryAccommodationInfoDb
+    {
+        /// <summary>
+        /// Represents the stage the Temporary Accomodation tenure is in.
+        /// Possible values: Matched | Under Offer | Accepted | Processing | Awaiting Approval | Completed
+        /// </summary>
+        public string BookingStatus { get; set; }
+        public TemporaryAccommodationOfficerDb AssignedOfficer { get; set; }
+    }
+}

--- a/Hackney.Shared.Tenure/Infrastructure/TemporaryAccommodationOfficerDb.cs
+++ b/Hackney.Shared.Tenure/Infrastructure/TemporaryAccommodationOfficerDb.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Hackney.Shared.Tenure.Infrastructure
+{
+    public class TemporaryAccommodationOfficerDb
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Hackney.Shared.Tenure/Infrastructure/TenureInformationDb.cs
+++ b/Hackney.Shared.Tenure/Infrastructure/TenureInformationDb.cs
@@ -88,8 +88,10 @@ namespace Hackney.Shared.Tenure.Infrastructure
         [DynamoDBProperty(Converter = typeof(DynamoDbBoolConverter))]
         public bool? HasOffsiteStorage { get; set; }
 
+        [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<TemporaryAccommodationInfoDb>))]
+        public TemporaryAccommodationInfoDb TempAccInfo { get; set; }
+
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<FurtherAccountInformation>))]
         public FurtherAccountInformation FurtherAccountInformation { get; set; }
-
     }
 }

--- a/Hackney.Shared.Tenure/Infrastructure/TenureInformationDb.cs
+++ b/Hackney.Shared.Tenure/Infrastructure/TenureInformationDb.cs
@@ -89,7 +89,7 @@ namespace Hackney.Shared.Tenure.Infrastructure
         public bool? HasOffsiteStorage { get; set; }
 
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<TemporaryAccommodationInfoDb>))]
-        public TemporaryAccommodationInfoDb TempAccInfo { get; set; }
+        public TemporaryAccommodationInfoDb TempAccommodationInfo { get; set; }
 
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<FurtherAccountInformation>))]
         public FurtherAccountInformation FurtherAccountInformation { get; set; }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PROJECT_NAME := hackney-shared-tenure-test
+
+.PHONY: clean
+clean:
+	docker rmi ${PROJECT_NAME}
+	-docker rmi $$(docker images --filter "dangling=true" -q --no-trunc)
+
+.PHONY: test
+test:
+	-docker-compose run --rm ${PROJECT_NAME}
+	-make clean
+
+.PHONY: ensure-dotnet-format
+ensure-dotnet-format:
+	-dotnet tool install -g dotnet-format
+	dotnet tool update -g dotnet-format
+
+.PHONY: checkf
+checkf:
+	make ensure-dotnet-format
+	dotnet-format --check
+
+.PHONY: lint
+lint:
+	make ensure-dotnet-format
+	dotnet format

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 PROJECT_NAME := hackney-shared-tenure-test
 
+# The dangling image removal doesn't behave as expected on Windows Powershell.
+# It is recommended to run Makefile commands using `git bash` if you're using Windows.
+# If you decide to stick with Powershell regardless, everything except dangling image removal will still work,
+# however, you'll need to remove those <none> <none> images by listing out their hashes manually.
 .PHONY: clean
 clean:
 	docker rmi ${PROJECT_NAME}


### PR DESCRIPTION
# What:
 - Added a optional Temporary Accommodation (TA) sub-models to the Tenure models.
 - Added "Booking Status" to TA sub-model.
 - Added "Assigned Officer" to TA sub-model.
 - Added TA sub-model to the "CreateTenureRequestObject".
 - Added TA sub-model to the "EditTenureDetailsRequestObject".
 - Added a couple of missing tests on existing functionality.
 - Added missing null value handling to the Tenure model mapping.
 - Added a Makefile for easier local tests run.

# Why:
 - Created TA sub-models so that Temporary Accommodation specifics are grouped & contained within a single place under a Tenure model. This should make dealing with the Tenure models easier when the Tenure is not a TA tenure. Likewise when it's a TA tenure.
 - Added "Booking Status" so that we could record the state the TA Tenure is across different stages of the TA approval workflow. This will make tracking TA tenure workflow status & doing the filtering by that status easier.
 - Added "Assigned Officer" to give visibility on which officers are working on the booking. There are different officers across different stages of TA approval workflow, as well as different officers working across a single stage.
 - Edited the "CreateTenureRequestObject" so that the booking could be created with all the relevant TA information from the get go using the TenureInformation API's `[HttpPost] /api/v1/tenures/` endpoint.
 - Edited the "EditTenureDetailsRequestObject" so that we could edit the relevant TA information (like change booking status and assigned officer) as the booking progresses over the workflow stages. The edits will be handled via TenureInformation API's `[HttpPatch] /api/v1/tenures/{id}` endpoint

# Schema change:
We've inserted a model shown in the schema bellow into the root position of the Tenure Information models. We've did the same for the previously mentioned request models.

``` yaml
# Tenure Information root object:
{
   ...,
   tempAccommodationInfo: {
      bookingStatus: string,
      assignedOfficer: {
         firstName: string,
         lastName: string,
         email: string
       }
    }
   ...
}
```

# Notes:
 - We did not add the TA details object into the `UpdateTenureRequestObject` request model because this model is consumed by the `[HttpPatch] /api/v1/tenures/{id}/persons/{personId}` endpoint, which is used to update the partial Tenure sub-model within the Person model. The TA information is only relevant within the scope of the Tenure models.
 - There's no model mapping logic for the `EditTenureDetailsRequestObject` within this repository because the mapping within the TenureInformation API is done via the Entity Updater construct using some reflections based contraption.
 - The Entity Updater used by TenureInformation API does not recurse into sub-models, meaning the request models must always have matching schemas with the database models to prevent data loss due to patch endpoint implementation stamping over the sub-models of the main model.
 - This PR replaces the PR #28 . Comments were addressed.