### PR TITLE
TS-1405: Adding Id to the AssignedOfficer submodel within TempAccommodationInfo

### DIFF
--- a/Hackney.Shared.Tenure.Tests/Dockerfile
+++ b/Hackney.Shared.Tenure.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/Hackney.Shared.Tenure.Tests/Dockerfile
+++ b/Hackney.Shared.Tenure.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/core/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/EntityFactoryTest.cs
@@ -118,6 +118,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             var taOfficerEntity = domainTAOfficer.ToDatabase();
 
             // assert
+            taOfficerEntity.Id.Should().Be(domainTAOfficer.Id);
             taOfficerEntity.FirstName.Should().Be(domainTAOfficer.FirstName);
             taOfficerEntity.LastName.Should().Be(domainTAOfficer.LastName);
             taOfficerEntity.Email.Should().Be(domainTAOfficer.Email);
@@ -173,6 +174,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             var taOfficerDomain = entityTAOfficer.ToDomain();
 
             // assert
+            taOfficerDomain.Id.Should().Be(entityTAOfficer.Id);
             taOfficerDomain.FirstName.Should().Be(entityTAOfficer.FirstName);
             taOfficerDomain.LastName.Should().Be(entityTAOfficer.LastName);
             taOfficerDomain.Email.Should().Be(entityTAOfficer.Email);

--- a/Hackney.Shared.Tenure.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.Tenure.Tests/Factories/ResponseFactoryTest.cs
@@ -103,6 +103,7 @@ namespace Hackney.Shared.Tenure.Tests.Factories
             var taOfficerPresentation = domainTAOfficer.ToResponse();
 
             // assert
+            taOfficerPresentation.Id.Should().Be(domainTAOfficer.Id);
             taOfficerPresentation.FirstName.Should().Be(domainTAOfficer.FirstName);
             taOfficerPresentation.LastName.Should().Be(domainTAOfficer.LastName);
             taOfficerPresentation.Email.Should().Be(domainTAOfficer.Email);

--- a/Hackney.Shared.Tenure.Tests/Hackney.Shared.Tenure.Tests.csproj
+++ b/Hackney.Shared.Tenure.Tests/Hackney.Shared.Tenure.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Hackney.Shared.Tenure.Tests/Hackney.Shared.Tenure.Tests.csproj
+++ b/Hackney.Shared.Tenure.Tests/Hackney.Shared.Tenure.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Hackney.Shared.Tenure/Boundary/Response/TemporaryAccommodationOfficerResponse.cs
+++ b/Hackney.Shared.Tenure/Boundary/Response/TemporaryAccommodationOfficerResponse.cs
@@ -4,6 +4,7 @@ namespace Hackney.Shared.Tenure.Boundary.Response
 {
     public class TemporaryAccommodationOfficerResponse
     {
+        public Guid Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Email { get; set; }

--- a/Hackney.Shared.Tenure/Domain/TemporaryAccommodationOfficer.cs
+++ b/Hackney.Shared.Tenure/Domain/TemporaryAccommodationOfficer.cs
@@ -4,6 +4,7 @@ namespace Hackney.Shared.Tenure.Domain
 {
     public class TemporaryAccommodationOfficer
     {
+        public Guid Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Email { get; set; }

--- a/Hackney.Shared.Tenure/Factories/EntityFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/EntityFactory.cs
@@ -116,6 +116,7 @@ namespace Hackney.Shared.Tenure.Factories
 
             return new TemporaryAccommodationOfficerDb
             {
+                Id = taOfficerDomain.Id,
                 FirstName = taOfficerDomain.FirstName,
                 LastName = taOfficerDomain.LastName,
                 Email = taOfficerDomain.Email

--- a/Hackney.Shared.Tenure/Factories/EntityFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/EntityFactory.cs
@@ -91,6 +91,7 @@ namespace Hackney.Shared.Tenure.Factories
 
             return new TemporaryAccommodationOfficer
             {
+                Id = taOfficerEntity.Id,
                 FirstName = taOfficerEntity.FirstName,
                 LastName = taOfficerEntity.LastName,
                 Email = taOfficerEntity.Email

--- a/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Amazon.DynamoDBv2.Model;
 using Hackney.Shared.Tenure.Boundary.Response;
 using Hackney.Shared.Tenure.Domain;
 using Hackney.Shared.Tenure.Infrastructure;

--- a/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.Tenure/Factories/ResponseFactory.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Amazon.DynamoDBv2.Model;
 using Hackney.Shared.Tenure.Boundary.Response;
 using Hackney.Shared.Tenure.Domain;
 using Hackney.Shared.Tenure.Infrastructure;
@@ -58,6 +59,7 @@ namespace Hackney.Shared.Tenure.Factories
 
             return new TemporaryAccommodationOfficerResponse
             {
+                Id = taOfficerDomain.Id,
                 FirstName = taOfficerDomain.FirstName,
                 LastName = taOfficerDomain.LastName,
                 Email = taOfficerDomain.Email

--- a/Hackney.Shared.Tenure/Infrastructure/TemporaryAccommodationOfficerDb.cs
+++ b/Hackney.Shared.Tenure/Infrastructure/TemporaryAccommodationOfficerDb.cs
@@ -4,6 +4,7 @@ namespace Hackney.Shared.Tenure.Infrastructure
 {
     public class TemporaryAccommodationOfficerDb
     {
+        public Guid Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Email { get; set; }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1405

## Describe this PR

### *What is the problem we're trying to solve*

As part of the TempAccomodationInfo submodel, we have another submodel relating to the TA officer who is assigned to the tenure (AssignedOfficer). In order to have an unique identifier for the officer, we are adding an `Id` guid, which will then be filled with their guid in the Person table. This way we can reliably connect officers to records Person table and give the FE a unique Id for officers.

### *What changes have we introduced*

Added Id wherever needed and in tests.
Also upgraded the .NET version to 6.0 for tests only (no impact on the package itself).

### *Follow up actions after merging PR*

Update the consuming API.