### PR TITLE
TS-1416: Change to EndOfTenureDate validation so it can be on the StartOfTenureDate

### DIFF
--- a/Hackney.Shared.Tenure.Tests/Boundary/Validation/CreateTenureRequestValidatorTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Boundary/Validation/CreateTenureRequestValidatorTests.cs
@@ -9,6 +9,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
     public class CreateTenureRequestValidatorTests
     {
         public CreateTenureRequestValidation _classUnderTest;
+        DateTime _aSetDate = new DateTime(2024, 5, 7);
 
         public CreateTenureRequestValidatorTests()
         {
@@ -17,24 +18,36 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         private const string StringWithTags = "Some string with <tag> in it.";
 
         [Fact]
-        public void WhenEndDateisCorrectNoError()
+        public void WhenEndDateisAfterStartDateNoError()
         {
             var request = new CreateTenureRequestObject()
             {
-                EndOfTenureDate = DateTime.UtcNow.AddDays(1),
-                StartOfTenureDate = DateTime.UtcNow
+                EndOfTenureDate = _aSetDate.AddDays(1),
+                StartOfTenureDate = _aSetDate
             };
             var result = _classUnderTest.TestValidate(request);
             result.ShouldNotHaveValidationErrorFor(x => x.EndOfTenureDate);
         }
 
         [Fact]
-        public void WhenEndDateIsInCorrectHasError()
+        public void WhenEndDateisOnStartDateNoError()
         {
             var request = new CreateTenureRequestObject()
             {
-                EndOfTenureDate = DateTime.UtcNow,
-                StartOfTenureDate = DateTime.UtcNow.AddDays(1)
+                EndOfTenureDate = _aSetDate,
+                StartOfTenureDate = _aSetDate
+            };
+            var result = _classUnderTest.TestValidate(request);
+            result.ShouldNotHaveValidationErrorFor(x => x.EndOfTenureDate);
+        }
+
+        [Fact]
+        public void WhenEndDateIsIncorrectHasError()
+        {
+            var request = new CreateTenureRequestObject()
+            {
+                EndOfTenureDate = _aSetDate,
+                StartOfTenureDate = _aSetDate.AddDays(1)
             };
             var result = _classUnderTest.TestValidate(request);
             result.ShouldHaveValidationErrorFor(x => x.EndOfTenureDate)

--- a/Hackney.Shared.Tenure.Tests/Boundary/Validation/EditTenureDetailsRequestValidatorTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Boundary/Validation/EditTenureDetailsRequestValidatorTests.cs
@@ -9,6 +9,8 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
     public class EditTenureDetailsRequestValidatorTests
     {
         public EditTenureDetailsRequestValidation _classUnderTest;
+        DateTime _aSetDate = new DateTime(2024, 5, 7);
+
         private const string StringWithTags = "Some string with <tag> in it.";
 
         public EditTenureDetailsRequestValidatorTests()
@@ -21,7 +23,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new EditTenureDetailsRequestObject()
             {
-                StartOfTenureDate = DateTime.UtcNow,
+                StartOfTenureDate = _aSetDate,
                 EndOfTenureDate = null
             };
 
@@ -36,7 +38,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
             var request = new EditTenureDetailsRequestObject()
             {
                 StartOfTenureDate = null,
-                EndOfTenureDate = DateTime.UtcNow
+                EndOfTenureDate = _aSetDate
             };
 
             var result = _classUnderTest.TestValidate(request);
@@ -49,8 +51,21 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new EditTenureDetailsRequestObject()
             {
-                StartOfTenureDate = DateTime.UtcNow,
-                EndOfTenureDate = DateTime.UtcNow.AddDays(1)
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate.AddDays(1)
+            };
+
+            var result = _classUnderTest.TestValidate(request);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+        [Fact]
+        public void WhenEndDateIsEqualToStartDateNoError()
+        {
+            var request = new EditTenureDetailsRequestObject()
+            {
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate
             };
 
             var result = _classUnderTest.TestValidate(request);
@@ -63,8 +78,8 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new EditTenureDetailsRequestObject()
             {
-                StartOfTenureDate = DateTime.UtcNow,
-                EndOfTenureDate = DateTime.UtcNow.AddDays(-1)
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate.AddDays(-1)
             };
 
             var result = _classUnderTest.TestValidate(request);

--- a/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
@@ -10,7 +10,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
     {
         public TenureInformationValidatorWhenOnlyEndDate _classUnderTest;
 
-        private DateTime _now;
+        DateTime _now = new DateTime(2024, 5, 7);
 
         public TenureInformationValidatorWhenOnlyEndDateTests()
         {

--- a/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
@@ -10,6 +10,8 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
     {
         public TenureInformationValidatorWhenOnlyEndDate _classUnderTest;
 
+        private DateTime _now;
+
         public TenureInformationValidatorWhenOnlyEndDateTests()
         {
             _classUnderTest = new TenureInformationValidatorWhenOnlyEndDate();
@@ -22,7 +24,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
             var request = new TenureInformation()
             {
                 StartOfTenureDate = null,
-                EndOfTenureDate = DateTime.UtcNow.AddDays(1)
+                EndOfTenureDate = _now.AddDays(1)
             };
 
             var result = _classUnderTest.TestValidate(request);
@@ -35,8 +37,24 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new TenureInformation()
             {
-                StartOfTenureDate = DateTime.UtcNow,
-                EndOfTenureDate = DateTime.UtcNow.AddDays(1)
+                StartOfTenureDate = _now,
+                EndOfTenureDate = _now.AddDays(1)
+            };
+
+            var result = _classUnderTest.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(x => x.EndOfTenureDate);
+        }
+
+        [Fact]
+        public void WhenEndDateIsEqualToStartDateNoError()
+        {
+            var now = DateTime.UtcNow;
+
+            var request = new TenureInformation()
+            {
+                StartOfTenureDate = now,
+                EndOfTenureDate = now
             };
 
             var result = _classUnderTest.TestValidate(request);
@@ -47,10 +65,11 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         [Fact]
         public void WhenEndDateIsLessThanStartDateHasError()
         {
+            var now = DateTime.UtcNow;
             var request = new TenureInformation()
             {
-                StartOfTenureDate = DateTime.UtcNow,
-                EndOfTenureDate = DateTime.UtcNow.AddDays(-1)
+                StartOfTenureDate = now,
+                EndOfTenureDate = now.AddDays(-1)
             };
 
             var result = _classUnderTest.TestValidate(request);

--- a/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
@@ -65,11 +65,10 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         [Fact]
         public void WhenEndDateIsLessThanStartDateHasError()
         {
-            var now = DateTime.UtcNow;
             var request = new TenureInformation()
             {
-                StartOfTenureDate = now,
-                EndOfTenureDate = now.AddDays(-1)
+                StartOfTenureDate = _now,
+                EndOfTenureDate = _now.AddDays(-1)
             };
 
             var result = _classUnderTest.TestValidate(request);

--- a/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
@@ -49,12 +49,11 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         [Fact]
         public void WhenEndDateIsEqualToStartDateNoError()
         {
-            var now = DateTime.UtcNow;
 
             var request = new TenureInformation()
             {
-                StartOfTenureDate = now,
-                EndOfTenureDate = now
+                StartOfTenureDate = _now,
+                EndOfTenureDate = _now
             };
 
             var result = _classUnderTest.TestValidate(request);

--- a/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyEndDateTests.cs
@@ -10,7 +10,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
     {
         public TenureInformationValidatorWhenOnlyEndDate _classUnderTest;
 
-        DateTime _now = new DateTime(2024, 5, 7);
+        DateTime _aSetDate = new DateTime(2024, 5, 7);
 
         public TenureInformationValidatorWhenOnlyEndDateTests()
         {
@@ -24,7 +24,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
             var request = new TenureInformation()
             {
                 StartOfTenureDate = null,
-                EndOfTenureDate = _now.AddDays(1)
+                EndOfTenureDate = _aSetDate.AddDays(1)
             };
 
             var result = _classUnderTest.TestValidate(request);
@@ -37,8 +37,8 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new TenureInformation()
             {
-                StartOfTenureDate = _now,
-                EndOfTenureDate = _now.AddDays(1)
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate.AddDays(1)
             };
 
             var result = _classUnderTest.TestValidate(request);
@@ -52,8 +52,8 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
 
             var request = new TenureInformation()
             {
-                StartOfTenureDate = _now,
-                EndOfTenureDate = _now
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate
             };
 
             var result = _classUnderTest.TestValidate(request);
@@ -66,8 +66,8 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new TenureInformation()
             {
-                StartOfTenureDate = _now,
-                EndOfTenureDate = _now.AddDays(-1)
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate.AddDays(-1)
             };
 
             var result = _classUnderTest.TestValidate(request);

--- a/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyStartDateTests.cs
+++ b/Hackney.Shared.Tenure.Tests/Boundary/Validation/TenureInformationValidatorWhenOnlyStartDateTests.cs
@@ -9,6 +9,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
     public class TenureInformationValidatorWhenOnlyStartDateTests
     {
         public TenureInformationValidatorWhenOnlyStartDate _classUnderTest;
+        DateTime _aSetDate = new DateTime(2024, 5, 7);
 
         public TenureInformationValidatorWhenOnlyStartDateTests()
         {
@@ -20,7 +21,7 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new TenureInformation()
             {
-                StartOfTenureDate = DateTime.UtcNow,
+                StartOfTenureDate = _aSetDate,
                 EndOfTenureDate = null
             };
 
@@ -34,8 +35,22 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new TenureInformation()
             {
-                StartOfTenureDate = DateTime.UtcNow,
-                EndOfTenureDate = DateTime.UtcNow.AddDays(1)
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate.AddDays(1)
+            };
+
+            var result = _classUnderTest.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(x => x.EndOfTenureDate);
+        }
+
+        [Fact]
+        public void WhenEndDateIsEqualToStartDateNoError()
+        {
+            var request = new TenureInformation()
+            {
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate
             };
 
             var result = _classUnderTest.TestValidate(request);
@@ -48,8 +63,8 @@ namespace Hackney.Shared.Tenure.Tests.Boundary.Validation
         {
             var request = new TenureInformation()
             {
-                StartOfTenureDate = DateTime.UtcNow,
-                EndOfTenureDate = DateTime.UtcNow.AddDays(-1)
+                StartOfTenureDate = _aSetDate,
+                EndOfTenureDate = _aSetDate.AddDays(-1)
             };
 
             var result = _classUnderTest.TestValidate(request);

--- a/Hackney.Shared.Tenure/Boundary/Requests/Validation/CreateTenureRequestValidation.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/Validation/CreateTenureRequestValidation.cs
@@ -8,7 +8,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests.Validation
         public CreateTenureRequestValidation()
         {
             RuleFor(x => x.EndOfTenureDate)
-                .GreaterThan(x => x.StartOfTenureDate)
+                .GreaterThanOrEqualTo(x => x.StartOfTenureDate)
                 .WithErrorCode(ErrorCodes.TenureEndDate);
 
             RuleFor(x => x.PaymentReference).NotXssString()

--- a/Hackney.Shared.Tenure/Boundary/Requests/Validation/EditTenureDetailsRequestValidation.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/Validation/EditTenureDetailsRequestValidation.cs
@@ -12,7 +12,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests.Validation
             When(tenure => tenure.EndOfTenureDate != null && tenure.StartOfTenureDate != null, () =>
             {
                 RuleFor(x => x.EndOfTenureDate)
-               .GreaterThan(x => x.StartOfTenureDate)
+               .GreaterThanOrEqualTo(x => x.StartOfTenureDate)
                .WithErrorCode(ErrorCodes.TenureEndDate);
             });
 

--- a/Hackney.Shared.Tenure/Boundary/Requests/Validation/ErrorCodes.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/Validation/ErrorCodes.cs
@@ -3,6 +3,6 @@ namespace Hackney.Shared.Tenure.Boundary.Requests.Validation
     public static class ErrorCodes
     {
         public const string XssCheckFailure = "W42";
-        public const string TenureEndDate = "W29";
+        public const string TenureEndDate = "W59";
     }
 }

--- a/Hackney.Shared.Tenure/Boundary/Requests/Validation/TenureInformationValidatorWhenOnlyEndDate.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/Validation/TenureInformationValidatorWhenOnlyEndDate.cs
@@ -14,7 +14,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests.Validation
             RuleFor(x => x.StartOfTenureDate)
                 .NotNull();
 
-            // the end date must be greater than start date
+            // the end date must be greater than or the same as the start date
             RuleFor(x => x.EndOfTenureDate)
             .GreaterThanOrEqualTo(x => x.StartOfTenureDate)
             .WithErrorCode(ErrorCodes.TenureEndDate);

--- a/Hackney.Shared.Tenure/Boundary/Requests/Validation/TenureInformationValidatorWhenOnlyEndDate.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/Validation/TenureInformationValidatorWhenOnlyEndDate.cs
@@ -16,7 +16,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests.Validation
 
             // the end date must be greater than start date
             RuleFor(x => x.EndOfTenureDate)
-            .GreaterThan(x => x.StartOfTenureDate)
+            .GreaterThanOrEqualTo(x => x.StartOfTenureDate)
             .WithErrorCode(ErrorCodes.TenureEndDate);
         }
     }

--- a/Hackney.Shared.Tenure/Boundary/Requests/Validation/TenureInformationValidatorWhenOnlyStartDate.cs
+++ b/Hackney.Shared.Tenure/Boundary/Requests/Validation/TenureInformationValidatorWhenOnlyStartDate.cs
@@ -13,7 +13,7 @@ namespace Hackney.Shared.Tenure.Boundary.Requests.Validation
             When(tenure => tenure.EndOfTenureDate != null, () =>
             {
                 RuleFor(x => x.StartOfTenureDate)
-                    .LessThan(x => x.EndOfTenureDate)
+                    .LessThanOrEqualTo(x => x.EndOfTenureDate)
                     .WithErrorCode(ErrorCodes.TenureEndDate);
             });
         }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1416

## Describe this PR

### *What is the problem we're trying to solve*

The BTA tool needs to be able to end a booking on the same day it starts. After convos with Housing and Finance (see ticket) we are now proceeding with such changes.

### *What changes have we introduced*

Changes to validation + test
Also minor refactoring of surrounding tests as date setting was not super solid

### *Follow up actions after merging PR*

Updating package version in consuming API + listener (for coherence)