### PR TITLE
Adds new TenureRefusedDate

### DIFF
--- a/Hackney.Shared.Tenure/Domain/FurtherAccountInformation.cs
+++ b/Hackney.Shared.Tenure/Domain/FurtherAccountInformation.cs
@@ -9,6 +9,7 @@ namespace Hackney.Shared.Tenure.Domain
         public DateTime? RentLetterSentDate { get; set; }
         public DateTime? RentCardGivenDate { get; set; }
         public DateTime? TenureAcceptedDate { get; set; }
+        public DateTime? TenureRefusedDate { get; set; }
         public bool? IsSection208NoticeSent { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1424?atlOrigin=eyJpIjoiNTRkZjhhOWIzNDJkNDhiZThiMmE1ODAxYzczNmZkNDIiLCJwIjoiaiJ9 

## Describe this PR

### *What is the problem we're trying to solve*
TA officers will need to be able to record a date of when a resident rejects a booking that has been offered to them.

### *What changes have we introduced*
Adds a TenureRefusedDate date field to Further Account Information domain object.

### *Follow up actions after merging PR*

The tenure API will be updated.